### PR TITLE
docs(datetime): fix typo

### DIFF
--- a/reference/datetime/datetimeinterface/diff.xml
+++ b/reference/datetime/datetimeinterface/diff.xml
@@ -70,7 +70,7 @@
    entre les deux dates&return.falseforfailure;.
   </para>
   <para>
-   La veleur de retour représente de façon plus détaillé l'intervale à appliquer
+   La valeur de retour représente de façon plus détaillé l'intervale à appliquer
    sur l'objet original (<parameter>$this</parameter> ou
    <parameter>$originObject</parameter>) pour arriver à
    <parameter>$targetObject</parameter>. Cette procédure n'est pas toujours


### PR DESCRIPTION
Hi 🖖 

Fix typo in doc for datetime